### PR TITLE
Prevent of destroying undefined word count container

### DIFF
--- a/docs/features/word-count.md
+++ b/docs/features/word-count.md
@@ -92,7 +92,7 @@ ClassicEditor
 ## Common API
 
 The {@link module:word-count/wordcount~WordCount} plugin provides:
-  * {@link module:word-count/wordcount~WordCount#wordCountContainer} method. It returns a self-updating HTML element which is updated with the current number of words and characters in the editor. There is a possibility to remove "Words" or "Characters" counters with proper configuration of {@link module:word-count/wordcount~WordCountConfig#displayWords} and {@link module:word-count/wordcount~WordCountConfig#displayCharacters},
+  * {@link module:word-count/wordcount~WordCount#wordCountContainer} getter. It returns a self-updating HTML element which is updated with the current number of words and characters in the editor. There is a possibility to remove "Words" or "Characters" counters with proper configuration of {@link module:word-count/wordcount~WordCountConfig#displayWords} and {@link module:word-count/wordcount~WordCountConfig#displayCharacters},
   * {@link module:word-count/wordcount~WordCount#event:update update event} which is fired whenever the plugins update the number of counted words and characters. There is a possibility to run own callback function with updated values. Please note that update event is throttled.
 
 <info-box>

--- a/src/wordcount.js
+++ b/src/wordcount.js
@@ -136,8 +136,10 @@ export default class WordCount extends Plugin {
 	 * @inheritDoc
 	 */
 	destroy() {
-		this._outputView.element.remove();
-		this._outputView.destroy();
+		if ( this._outputView ) {
+			this._outputView.element.remove();
+			this._outputView.destroy();
+		}
 
 		super.destroy();
 	}

--- a/tests/wordcount.js
+++ b/tests/wordcount.js
@@ -159,21 +159,13 @@ describe( 'WordCount', () => {
 					.catch( done );
 			} );
 
-			describe( 'container not created', () => {
-				let editor;
-
-				beforeEach( () => {
-					return VirtualTestEditor.create( {
-						plugins: [ WordCount, Paragraph ]
-					} )
-						.then( _editor => {
-							editor = _editor;
-						} );
-				} );
-
-				it( 'should not throw an error', () => {
-					return editor.destroy();
-				} );
+			it( 'should not throw an error if container is not specified', () => {
+				return VirtualTestEditor.create( {
+					plugins: [ WordCount, Paragraph ]
+				} )
+					.then( editor => {
+						return editor.destroy();
+					} );
 			} );
 		} );
 	} );

--- a/tests/wordcount.js
+++ b/tests/wordcount.js
@@ -158,6 +158,23 @@ describe( 'WordCount', () => {
 					.then( done )
 					.catch( done );
 			} );
+
+			describe( 'container not created', () => {
+				let editor;
+
+				beforeEach( () => {
+					return VirtualTestEditor.create( {
+						plugins: [ WordCount, Paragraph ]
+					} )
+						.then( _editor => {
+							editor = _editor;
+						} );
+				} );
+
+				it( 'should not throw an error', () => {
+					return editor.destroy();
+				} );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevent of destroying undefined word count container. Closes ckeditor/ckeditor5#2575.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
